### PR TITLE
Fix tracking multiple consignments

### DIFF
--- a/src/service/TrackingService/TrackingResponse.php
+++ b/src/service/TrackingService/TrackingResponse.php
@@ -60,18 +60,10 @@ class TrackingResponse extends AbstractResponse {
         
         $this->consignments = [];
         
-        if(is_array($this->simpleXml->Consignment) === true) {
-                
-            foreach ($this->simpleXml->Consignment as $cs) {
-                
-                $this->consignments[] = new Consignment($cs);
+        foreach ($this->simpleXml->Consignment as $cs) {
 
-            }
-
-        } else {
-
-            $this->consignments[] = new Consignment($this->simpleXml->Consignment);
-
+            $this->consignments[] = new Consignment($cs);
+            
         }
         
     }


### PR DESCRIPTION
Previously only the first consignment was returned.

Removing the test checking $this->simpleXml->Consignment being an array of consignments - it's always a SimpleXmlElement - correctly sets the array of consignments.